### PR TITLE
Fix gzip and disable cert verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aes"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +31,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +59,20 @@ name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+
+[[package]]
+name = "async-compression"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -86,6 +121,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -234,6 +290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +355,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -765,6 +840,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1197,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "cookie",
@@ -1141,6 +1226,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ lru = "0.7"
 m3u8-rs = "4.0"
 oxilangtag = "0.1"
 rand = "0.8"
-reqwest = { version = "0.11", features = ["rustls-tls", "gzip", "cookies"], default-features = false }
+reqwest = { version = "0.11", features = ["rustls-tls", "gzip", "brotli", "deflate", "cookies"], default-features = false }
 reqwest-middleware = "0.1"
 reqwest-retry = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ lru = "0.7"
 m3u8-rs = "4.0"
 oxilangtag = "0.1"
 rand = "0.8"
-reqwest = { version = "0.11", features = ["rustls-tls", "cookies"], default-features = false }
+reqwest = { version = "0.11", features = ["rustls-tls", "gzip", "cookies"], default-features = false }
 reqwest-middleware = "0.1"
 reqwest-retry = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,11 +33,6 @@ pub struct DownloadOptions {
     /// stream
     #[clap(long, value_parser)]
     pub choose_stream: bool,
-
-    /// (TLS) By default, every SSL connection curl makes is verified to be secure.
-    /// This option allows request to proceed and operate even for server connections otherwise considered insecure.
-    #[clap(long, value_parser, short='k')]
-    pub insecure: bool,
 }
 
 #[derive(Parser, Clone, Debug)]
@@ -68,4 +63,9 @@ pub struct NetworkOptions {
     /// Copy GET query parameters from m3u8_url to all subsequent network requests
     #[clap(short = 'q', long, value_parser)]
     pub copy_query: bool,
+
+    /// By default, every TLS connection is verified to be secure.
+    /// This option allows livestream-dl to skip verification and proceed without checking.
+    #[clap(short = 'k', long, value_parser)]
+    pub insecure: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,11 @@ pub struct DownloadOptions {
     /// stream
     #[clap(long, value_parser)]
     pub choose_stream: bool,
+
+    /// (TLS) By default, every SSL connection curl makes is verified to be secure.
+    /// This option allows request to proceed and operate even for server connections otherwise considered insecure.
+    #[clap(long, value_parser, short='k')]
+    pub insecure: bool,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/src/livestream/mod.rs
+++ b/src/livestream/mod.rs
@@ -87,8 +87,10 @@ impl Livestream {
     /// and all of its alternative media streams
     pub async fn new(url: &Url, options: &Args) -> Result<(Self, Stopper)> {
         // Create reqwest client
-        let client =
-            Client::builder().timeout(Duration::from_secs(options.network_options.timeout));
+        // and accept invalid certs
+        let client = Client::builder()
+            .danger_accept_invalid_certs(true)
+            .timeout(Duration::from_secs(options.network_options.timeout));
 
         // Add cookie provider if needed
         let client = if let Some(cookies_path) = &options.network_options.cookies {

--- a/src/livestream/mod.rs
+++ b/src/livestream/mod.rs
@@ -87,10 +87,13 @@ impl Livestream {
     /// and all of its alternative media streams
     pub async fn new(url: &Url, options: &Args) -> Result<(Self, Stopper)> {
         // Create reqwest client
-        // and accept invalid certs
-        let client = Client::builder()
-            .danger_accept_invalid_certs(true)
-            .timeout(Duration::from_secs(options.network_options.timeout));
+        let mut client =
+            Client::builder().timeout(Duration::from_secs(options.network_options.timeout));
+
+        // If insecure mode is turned on, ignore the certificate check
+        if options.download_options.insecure {
+            client = client.danger_accept_invalid_certs(true);
+        }
 
         // Add cookie provider if needed
         let client = if let Some(cookies_path) = &options.network_options.cookies {

--- a/src/livestream/mod.rs
+++ b/src/livestream/mod.rs
@@ -87,13 +87,9 @@ impl Livestream {
     /// and all of its alternative media streams
     pub async fn new(url: &Url, options: &Args) -> Result<(Self, Stopper)> {
         // Create reqwest client
-        let mut client =
-            Client::builder().timeout(Duration::from_secs(options.network_options.timeout));
-
-        // If insecure mode is turned on, ignore the certificate check
-        if options.download_options.insecure {
-            client = client.danger_accept_invalid_certs(true);
-        }
+        let client = Client::builder()
+            .timeout(Duration::from_secs(options.network_options.timeout))
+            .danger_accept_invalid_certs(options.network_options.insecure);
 
         // Add cookie provider if needed
         let client = if let Some(cookies_path) = &options.network_options.cookies {


### PR DESCRIPTION
some links have gzip enabled so they need to be parsed with gzip, and some other sites' certificates can be unchecked